### PR TITLE
Timer disabled when another task is in progress

### DIFF
--- a/frontend/src/pages/ViewTask.css
+++ b/frontend/src/pages/ViewTask.css
@@ -58,7 +58,17 @@
 .timer-display h2 {
     font-size: 2em;
     margin-bottom: 15px;
-}    
+}   
+
+.disabled-timer {
+    color: lightgray;
+}
+
+.another-task-message {
+  color: lightcoral;
+  text-align: center;
+  margin-top: 10px;
+}
 
 .timer-buttons {
     display: flex;


### PR DESCRIPTION
Previously, if you started a timer for one task, it showed up on all task pages. Now if a timer is running or paused for one task, the timer is disabled for all other tasks and shows a feedback message. 