### PR TITLE
Manual time entry

### DIFF
--- a/frontend/src/pages/ViewTask.css
+++ b/frontend/src/pages/ViewTask.css
@@ -97,7 +97,7 @@
 
 .manual-time-modal {
     --width: 300px;
-    --height: 300px;
+    --height: 350px;
     --border-radius: 10px;
     --background: white;
     --box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);

--- a/frontend/src/pages/ViewTask.css
+++ b/frontend/src/pages/ViewTask.css
@@ -83,6 +83,18 @@
     line-height: 3;
 }
 
+.manual-time {
+    width: 200px;
+    height: 40px;
+    font-size: 12px;
+    margin-top: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center; 
+    margin: 20px auto; 
+    margin-bottom: 0px;
+}
+
 .completed-container {
     display: flex;
     align-items: center;

--- a/frontend/src/pages/ViewTask.css
+++ b/frontend/src/pages/ViewTask.css
@@ -95,6 +95,20 @@
     margin-bottom: 0px;
 }
 
+.manual-time-modal {
+    --width: 300px;
+    --height: 300px;
+    --border-radius: 10px;
+    --background: white;
+    --box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+    --padding: 20px;
+    --margin: auto;
+    --top: 50%;
+    --left: 50%;
+    --transform: translate(-50%, -50%);
+    --position: absolute;
+}
+
 .completed-container {
     display: flex;
     align-items: center;

--- a/frontend/src/pages/ViewTask.tsx
+++ b/frontend/src/pages/ViewTask.tsx
@@ -320,6 +320,8 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
               </div>
             </div>
             <IonItemDivider />
+            <IonButton className="manual-time" color="medium">Enter Time Manually</IonButton>
+            <IonItemDivider />
             <div className="completed-container">
               <IonText className="completed-label">
                 <p><strong>Task Completed:</strong></p>

--- a/frontend/src/pages/ViewTask.tsx
+++ b/frontend/src/pages/ViewTask.tsx
@@ -401,11 +401,32 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
             </IonItem>
             <IonItem>
               <IonLabel position="stacked">Hours</IonLabel>
-              <IonInput type="number" value={manualHours} onIonChange={e => setManualHours(parseInt(e.detail.value!, 10))} />
+              <IonInput 
+                type="number" 
+                inputmode="numeric"
+                min="0" 
+                step="1" 
+                value={manualHours} 
+                onIonChange={e => {
+                  const value = parseInt(e.detail.value!, 10);
+                  setManualHours(isNaN(value) || value < 0 ? 0 : value);
+                }} 
+              />
             </IonItem>
             <IonItem>
               <IonLabel position="stacked">Minutes</IonLabel>
-              <IonInput type="number" value={manualMinutes} onIonChange={e => setManualMinutes(parseInt(e.detail.value!, 10))} />
+              <IonInput 
+                type="number" 
+                inputmode="numeric"
+                min="0" 
+                max="59" 
+                step="1" 
+                value={manualMinutes} 
+                onIonChange={e => {
+                  const value = parseInt(e.detail.value!, 10);
+                  setManualMinutes(isNaN(value) || value < 0 ? 0 : value);
+                }} 
+              />
             </IonItem>
             <IonButton expand="block" onClick={handleManualTimeSubmit}>Submit</IonButton>
             <IonButton expand="block" color="light" onClick={handleModalCancel}>Cancel</IonButton>

--- a/frontend/src/pages/ViewTask.tsx
+++ b/frontend/src/pages/ViewTask.tsx
@@ -155,7 +155,8 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
     setIsRunning(false);
     setIsPaused(false);
 
-    await updateTimeSpent();
+    const additionalTime = timer / 3600; // Convert seconds to hours
+    await updateTimeSpent(additionalTime);
 
     setTimer(0);
     localStorage.removeItem('timer');
@@ -165,11 +166,22 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
     localStorage.removeItem('runningTaskName');
   };
 
-  const handleManualTimeSubmit = () => {
+  const handleManualTimeSubmit = async () => {
     if (manualHours !== null && manualMinutes !== null) {
+      // Update the time 
       const additionalTime = manualHours + manualMinutes / 60;
-      // Update the task's time spent with the manually entered time
-      //setTask(prevTask => prevTask ? { ...prevTask, time_spent: prevTask.time_spent + additionalTime } : null);
+      await updateTimeSpent(additionalTime);
+
+      // Reset any timer 
+      setIsRunning(false);
+      setIsPaused(false);
+      setTimer(0);
+      localStorage.removeItem('timer');
+      localStorage.removeItem('isRunning');
+      localStorage.removeItem('isPaused');
+      localStorage.removeItem('runningTaskId');
+      localStorage.removeItem('runningTaskName');
+
       setShowModal(false);
     }
   };
@@ -190,7 +202,6 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
     } catch (error) {
       console.error("Error fetching task:", error);
     }
-    // TODO: should this remove the task from any future dates in the plan since it's done?
   };
 
   const openTask = async () => {
@@ -211,9 +222,8 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
     }
   };
 
-  const updateTimeSpent = async () => {
+  const updateTimeSpent = async (additionalTime: number) => {
     setLoadingTimeSpent(true)
-    const additionalTime = timer / 3600; // Convert seconds to hours
 
     try {
       const response = await fetch(`http://localhost:5050/api/viewTask/updateTimeSpent/${params.id}`, {
@@ -358,6 +368,9 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
         {/* Modal for entering time manually */}
         <IonModal isOpen={showModal} onDidDismiss={() => setShowModal(false)} className="manual-time-modal">
           <IonContent className="ion-padding">
+            <IonItem>
+              <IonText><strong>Time Spent:</strong></IonText>
+            </IonItem>
             <IonItem>
               <IonLabel position="stacked">Hours</IonLabel>
               <IonInput type="number" value={manualHours} onIonChange={e => setManualHours(parseInt(e.detail.value!, 10))} />

--- a/frontend/src/pages/ViewTask.tsx
+++ b/frontend/src/pages/ViewTask.tsx
@@ -338,7 +338,8 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
               {/* Timer control buttons */}
               <div className="timer-buttons">
               {anotherTaskRunning ? (
-                  <IonText className="another-task-message">You have a task in progress: <strong>{localStorage.getItem('runningTaskName')}</strong>. Please stop it before starting this task.</IonText>
+                  <IonText className="another-task-message">You have a task in progress: <strong>{localStorage.getItem('runningTaskName')}</strong>. 
+                  Please stop it before starting this task.</IonText>
                 ) : (
                   <>
                     {isRunning && !isPaused ? (
@@ -359,7 +360,16 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
             </div>
             {/* Manual time entry */}
             <IonItemDivider />
-            <IonButton className="manual-time" color="medium" onClick={() => setShowModal(true)}>Enter Time Manually</IonButton>
+            <div title={anotherTaskRunning ? "Please stop the other task to enter time." : ""}>
+              <IonButton 
+                className="manual-time" 
+                color="medium" 
+                onClick={() => setShowModal(true)}
+                disabled={anotherTaskRunning}
+              >
+                Enter Time Manually
+              </IonButton>
+            </div>
             {/* "Completed" checkbox */}
             <IonItemDivider />
             <div className="completed-container">

--- a/frontend/src/pages/ViewTask.tsx
+++ b/frontend/src/pages/ViewTask.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { IonButton, IonContent, IonPage, IonTitle, IonToolbar, IonText, IonItemDivider, IonSpinner } from "@ionic/react";
+import { IonButton, IonContent, IonPage, IonTitle, IonToolbar, IonText, IonItemDivider, IonSpinner, IonModal, IonItem, IonLabel, IonInput } from "@ionic/react";
 import { useHistory } from "react-router-dom";
 import { useLocation } from "react-router-dom";
 import './ViewTask.css'; // Import the CSS file
@@ -23,6 +23,9 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
   const [checkboxLoading, setCheckboxLoading] = useState(false); 
   const [loadingTimeSpent, setLoadingTimeSpent] = useState(false); 
   const [anotherTaskRunning, setAnotherTaskRunning] = useState(false); 
+  const [showModal, setShowModal] = useState(false);
+  const [manualHours, setManualHours] = useState<number | null>(null);
+  const [manualMinutes, setManualMinutes] = useState<number | null>(null);
 
   // Either load or start from 0
   const [timer, setTimer] = useState<number>(() => {
@@ -160,6 +163,15 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
     localStorage.removeItem('isPaused');
     localStorage.removeItem('runningTaskId');
     localStorage.removeItem('runningTaskName');
+  };
+
+  const handleManualTimeSubmit = () => {
+    if (manualHours !== null && manualMinutes !== null) {
+      const additionalTime = manualHours + manualMinutes / 60;
+      // Update the task's time spent with the manually entered time
+      //setTask(prevTask => prevTask ? { ...prevTask, time_spent: prevTask.time_spent + additionalTime } : null);
+      setShowModal(false);
+    }
   };
 
   const closeTask = async () => {
@@ -320,7 +332,7 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
               </div>
             </div>
             <IonItemDivider />
-            <IonButton className="manual-time" color="medium">Enter Time Manually</IonButton>
+            <IonButton className="manual-time" color="medium" onClick={() => setShowModal(true)}>Enter Time Manually</IonButton>
             <IonItemDivider />
             <div className="completed-container">
               <IonText className="completed-label">
@@ -342,6 +354,22 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
           // Show error message if task is missing
           <IonText>Error: Task not found</IonText>
         )}
+
+        {/* Modal for entering time manually */}
+        <IonModal isOpen={showModal} onDidDismiss={() => setShowModal(false)} className="manual-time-modal">
+          <IonContent className="ion-padding">
+            <IonItem>
+              <IonLabel position="stacked">Hours</IonLabel>
+              <IonInput type="number" value={manualHours} onIonChange={e => setManualHours(parseInt(e.detail.value!, 10))} />
+            </IonItem>
+            <IonItem>
+              <IonLabel position="stacked">Minutes</IonLabel>
+              <IonInput type="number" value={manualMinutes} onIonChange={e => setManualMinutes(parseInt(e.detail.value!, 10))} />
+            </IonItem>
+            <IonButton expand="block" onClick={handleManualTimeSubmit}>Submit</IonButton>
+            <IonButton expand="block" color="light" onClick={() => setShowModal(false)}>Cancel</IonButton>
+          </IonContent>
+        </IonModal>
       </IonContent>
     </IonPage>
   );  

--- a/frontend/src/pages/ViewTask.tsx
+++ b/frontend/src/pages/ViewTask.tsx
@@ -152,39 +152,49 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
   };
 
   const handleStop = async () => {
-    setIsRunning(false);
-    setIsPaused(false);
+    // Pause timer in case they hit cancel in the modal
+    handlePause()
 
+    // Set modal values from timer
     const additionalTime = timer / 3600; // Convert seconds to hours
+    setManualHours(Math.floor(additionalTime))
+    setManualMinutes(Math.round((additionalTime % 1) * 60))
+
+    // Pull up modal to confirm time
+    setShowModal(true)
+  };
+
+  const handleManualTimeSubmit = async () => {
+    // Update the time 
+    const additionalTime = (manualHours ?? 0) + (manualMinutes ?? 0) / 60; 
     await updateTimeSpent(additionalTime);
 
+    // Reset any timer 
+    setIsRunning(false);
+    setIsPaused(false);
     setTimer(0);
     localStorage.removeItem('timer');
     localStorage.removeItem('isRunning');
     localStorage.removeItem('isPaused');
     localStorage.removeItem('runningTaskId');
     localStorage.removeItem('runningTaskName');
+
+    // Reset modal values
+    setManualHours(null)
+    setManualMinutes(null)
+
+    setShowModal(false);
+
   };
 
-  const handleManualTimeSubmit = async () => {
-    if (manualHours !== null && manualMinutes !== null) {
-      // Update the time 
-      const additionalTime = manualHours + manualMinutes / 60;
-      await updateTimeSpent(additionalTime);
+  const handleModalCancel = () => {
+    // Reset modal values
+    setManualHours(null)
+    setManualMinutes(null)
 
-      // Reset any timer 
-      setIsRunning(false);
-      setIsPaused(false);
-      setTimer(0);
-      localStorage.removeItem('timer');
-      localStorage.removeItem('isRunning');
-      localStorage.removeItem('isPaused');
-      localStorage.removeItem('runningTaskId');
-      localStorage.removeItem('runningTaskName');
-
-      setShowModal(false);
-    }
-  };
+    // Close modal
+    setShowModal(false)
+  }
 
   const closeTask = async () => {
     try {
@@ -293,7 +303,7 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
                   minute: "2-digit",// "59"
                   hour12: true      // AM/PM format
                 })}</p>
-                <p><strong>Time Estimate: </strong>{task.total_time_estimate} hours</p>
+                <p><strong>Time Estimated: </strong>{task.total_time_estimate} hours</p>
                 <p><strong>Time Spent: </strong>{task.time_spent.toFixed(2)} {task.time_spent === 1 ? "hour" : "hours"}</p>
               </IonText>
               {task.priority !== undefined && (
@@ -322,7 +332,7 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
               {/* Timer control buttons */}
               <div className="timer-buttons">
               {anotherTaskRunning ? (
-                  <IonText className="another-task-message">You have a task in progress: {localStorage.getItem('runningTaskName')}. Please stop it before starting this task.</IonText>
+                  <IonText className="another-task-message">You have a task in progress: <strong>{localStorage.getItem('runningTaskName')}</strong>. Please stop it before starting this task.</IonText>
                 ) : (
                   <>
                     {isRunning && !isPaused ? (
@@ -380,7 +390,7 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
               <IonInput type="number" value={manualMinutes} onIonChange={e => setManualMinutes(parseInt(e.detail.value!, 10))} />
             </IonItem>
             <IonButton expand="block" onClick={handleManualTimeSubmit}>Submit</IonButton>
-            <IonButton expand="block" color="light" onClick={() => setShowModal(false)}>Cancel</IonButton>
+            <IonButton expand="block" color="light" onClick={handleModalCancel}>Cancel</IonButton>
           </IonContent>
         </IonModal>
       </IonContent>

--- a/frontend/src/pages/ViewTask.tsx
+++ b/frontend/src/pages/ViewTask.tsx
@@ -120,7 +120,7 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
     return () => clearInterval(timerInterval);
   }, [isRunning, isPaused]); 
 
-  // Save timer state 
+  // Set timer state 
   useEffect(() => {
     localStorage.setItem('timer', timer.toString());
     localStorage.setItem('isRunning', JSON.stringify(isRunning));
@@ -138,6 +138,7 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
     history.replace("/tasklist");
   };
 
+  // Timer start/resume
   const handleStart = () => {
     localStorage.setItem('runningTaskId', params.id);
     localStorage.setItem('runningTaskName', task?.name ?? "None");
@@ -146,11 +147,13 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
     setIsPaused(false);
   };
 
+  // Timer pause
   const handlePause = () => {
     setIsPaused(true);
     setIsRunning(false);
   };
 
+  // Timer stop - opens modal to handle time checking/editing
   const handleStop = async () => {
     // Pause timer in case they hit cancel in the modal
     handlePause()
@@ -164,6 +167,7 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
     setShowModal(true)
   };
 
+  // Submit clicked 
   const handleManualTimeSubmit = async () => {
     // Update the time 
     const additionalTime = (manualHours ?? 0) + (manualMinutes ?? 0) / 60; 
@@ -183,8 +187,8 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
     setManualHours(null)
     setManualMinutes(null)
 
+    // Close modal
     setShowModal(false);
-
   };
 
   const handleModalCancel = () => {
@@ -232,6 +236,7 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
     }
   };
 
+  // DB call for updating time spent
   const updateTimeSpent = async (additionalTime: number) => {
     setLoadingTimeSpent(true)
 
@@ -258,6 +263,7 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
     }
   };
 
+  // Task completed checked/unchecked
   const handleCheckboxChange = async () => {
     setCheckboxLoading(true)
     if (task?.completed) {
@@ -325,7 +331,7 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
                   <IonSpinner name="circles" />
                 </div>
               )}
-              
+              {/* Timer */}
               <IonText className={`timer-display ${anotherTaskRunning ? 'disabled-timer' : ''}`}>
                 <h2>{anotherTaskRunning ? '00:00:00' : new Date(timer * 1000).toISOString().substr(11, 8)}</h2>
               </IonText>
@@ -351,8 +357,10 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
                 )}
               </div>
             </div>
+            {/* Manual time entry */}
             <IonItemDivider />
             <IonButton className="manual-time" color="medium" onClick={() => setShowModal(true)}>Enter Time Manually</IonButton>
+            {/* "Completed" checkbox */}
             <IonItemDivider />
             <div className="completed-container">
               <IonText className="completed-label">


### PR DESCRIPTION
\*\*\*TIMER BUG FIX NEEDS MERGED FIRST\*\*\*

Adds a button where user can manually enter time in a modal. Also, when the timer is stopped, opens the modal with pre-populated values so they can make edits if it's wrong. 

Details:
- When "stop timer" is clicked, the timer is paused while the modal is pulled up so if they click "cancel" they don't lose the time. If they click "submit", the timer is cleared.
- Rounds the timer value to the nearest minute when pre-populating.
- The modal doesn't pre-populate from clicking "enter time manually" while a timer is running, only if "stop timer" is clicked.
- If a manual time is submitted while a timer is running, it will clear the timer. 