### PR TITLE
Implement Edit Task page, accessed from View Task page

### DIFF
--- a/.github/workflows/cypress-workflows.yaml
+++ b/.github/workflows/cypress-workflows.yaml
@@ -73,6 +73,6 @@ jobs:
         run: npx cypress run --spec "cypress/e2e/{login,signup}.cy.ts" --config video=false
         working-directory: frontend
 
-      - name: Run Cypress Tests for CreateTask
-        run: npx cypress run --spec "cypress/e2e/createTask.cy.ts" --config video=false
+      - name: Run Cypress Tests for Task Creation and Editing
+        run: npx cypress run --spec "cypress/e2e/{createTask,editTask}.cy.ts" --config video=false
         working-directory: frontend

--- a/backend/src/controllers/createTasksController.ts
+++ b/backend/src/controllers/createTasksController.ts
@@ -2,19 +2,8 @@ import { Request, Response } from "express";
 import { db } from "../config/firebase";
 
 export const addNewTask = async (req: Request, res: Response) => {
-  const {
-    user_id,
-    name,
-    notes,
-    location,
-    due_datetime,
-    course_id,
-    tags,
-    next_start_time,
-    next_end_time,
-    time_spent,
-    total_time_estimate,
-    completed,
+  const { user_id, name, notes, location, due_datetime, course_id, tags,
+    next_start_time, next_end_time, time_spent, total_time_estimate, completed,
   } = req.body;
 
   if (!name || !due_datetime) {
@@ -37,10 +26,6 @@ export const addNewTask = async (req: Request, res: Response) => {
 
     completed: completed,
   };
-
-  // if (!(next_start_time instanceof Date) || !(next_end_time instanceof Date)) {
-  //   return res.status(400).json({ error: "Invalid next_start_time or next_end_time" });
-  // }
 
   const nextWorktime = {
     start_time: next_start_time,
@@ -76,6 +61,42 @@ export const addNewTask = async (req: Request, res: Response) => {
     });
   } catch (error) {
     console.log(error);
+    res.status(500).json({ error: (error as Error).message });
+  }
+};
+
+
+export const updateTask = async (req: Request, res: Response) => {
+  const { taskid } = req.params;
+  const { name, notes, location, due_datetime, course_id, tags, total_time_estimate } = req.body;
+
+  try {
+    const taskRef = await db.collection("tasks").doc(taskid).get();
+
+    if (!taskRef.exists) {
+      return res.status(404).json({ error: "Task not found" });
+    }
+
+    // Update fields, TODO: only update changed fields
+    await db.collection("tasks").doc(taskid).update({
+      name: name,
+      notes: notes,
+      location: location,
+      due_datetime: due_datetime,
+      course_id: course_id,
+      tags: tags,
+      total_time_estimate: total_time_estimate,
+    });
+
+    // Return success response
+    res.status(200).json({
+      message: "Task updated successfully!",
+      taskId: taskid,
+      task: req.body
+    });
+
+  } catch (error) {
+    console.error(error);
     res.status(500).json({ error: (error as Error).message });
   }
 };

--- a/backend/src/routes/createTasksRoutes.ts
+++ b/backend/src/routes/createTasksRoutes.ts
@@ -1,8 +1,9 @@
 import express from "express";
-import { addNewTask } from "../controllers/createTasksController";
+import { addNewTask, updateTask } from "../controllers/createTasksController";
 
 const router = express.Router();
 
 router.post("/addnewtask", addNewTask);
+router.patch("/updatetask/:taskid", updateTask);
 
 export default router;

--- a/frontend/cypress/e2e/editTask.cy.ts
+++ b/frontend/cypress/e2e/editTask.cy.ts
@@ -1,0 +1,203 @@
+/// <reference types="cypress" />
+
+describe("CreateTask Page", () => {
+  beforeEach(() => {
+    cy.clearAllCookies();
+    cy.clearLocalStorage();
+    cy.visit("http://localhost:8100/login");
+    cy.get('.login-container').should('be.visible');
+
+    // Log in before each test if needed (adjust based on your auth method)
+    cy.intercept("POST", "http://localhost:5050/api/auth/login", {
+      statusCode: 200,
+      body: { token: "fake-jwt-token" }
+    }).as("loginAttempt");
+
+    cy.get('ion-input[placeholder="Email"]').type("valid@example.com");
+    cy.get('ion-input[placeholder="Password"]').type("validpassword");
+    cy.get('.signin-button').click();
+    cy.wait("@loginAttempt");
+
+    // Intercept API call before visiting View Task
+    cy.intercept("GET", "http://localhost:5050/api/viewTask/getTask/*", { fixture: "taskview.json" }).as("getTask");
+    cy.visit("http://localhost:8100/viewtask/123"); // Navigate to the page
+    cy.wait("@getTask"); // Wait for task data to load
+
+    // Intercept API call before visiting Edit Task
+    cy.intercept("GET", "http://localhost:5050/api/viewTask/getTask/*", { fixture: "taskview.json" }).as("getTask");
+    cy.get('.edit-button').click();
+    cy.wait("@getTask");
+  });
+
+  // =========================
+  //         Page view
+  // =========================
+  it("should import data from viewed task successfully in the Edit Task form", () => {
+    cy.get("ion-title").should('have.text', 'Edit Task');
+    cy.get("ion-input").eq(0).should('have.value', "Example task");  // name -- NOTE: cypress tests are inconsistent with aria-label
+    cy.get("ion-input").eq(1).should('have.value', "description");  // notes
+    cy.get("ion-input").eq(2).should('exist');  // location
+
+    cy.get("ion-datetime").eq(0).should('exist');
+    cy.get("ion-datetime").eq(0).find('span[slot="title"]').should('have.text', 'Due date/time');
+
+    // cy.get("ion-select[label='Course']").should('exist');  // uncommented until courses are fully connected
+    cy.get("ion-select[label='Tags']").should('exist');
+    cy.get("ion-input[label='Time Estimate (hours)']").find('input').should('have.value', 3);
+    cy.get('ion-toggle').eq(0).should('exist');
+    cy.get('.create-task-button').should('exist');
+  });
+
+  // ====================================================
+  //         Input updating and input validation
+  // ====================================================
+  it("should correctly update the task name input field", () => {
+    const newTaskName = "- This is a task name";
+    cy.get("ion-input").eq(0).type(newTaskName);
+    cy.get("ion-input").eq(0).find('input').should('have.value', "Example task" + newTaskName);
+  });
+
+  it("should not allow users to surpass the set max character length for names", () => {
+    const maxLength = 50;
+
+    // Enter invalid task name (longer than 50 characters), and check that length is <= 50
+    const invalidTaskName = "A ".repeat(60);
+    cy.get("ion-input").eq(0).find('input').clear().type(invalidTaskName);
+
+    // Check that invalid long name is truncated
+    const truncatedName = invalidTaskName.slice(0, maxLength);
+    cy.get("ion-input").eq(0).find('input').should('have.value', truncatedName);
+    cy.get("ion-input").eq(0).find('input').invoke('val').should('have.length.lessThan', maxLength + 1);
+  });
+
+  it("should correctly update the task notes input field", () => {
+    const newNotes = "- This is a note for the task";
+    cy.get("ion-input").eq(1).type(newNotes);
+    cy.get("ion-input").eq(1).find('input').should('have.value', "description" + newNotes);
+  });
+
+  it("should correctly update the task location input field", () => {
+    const newLocation = "New Location";
+    cy.get("ion-input").eq(2).type(newLocation);
+    cy.get("ion-input").eq(2).find('input').should('have.value', newLocation);
+  });
+
+  it("should correctly update the due date input field when inputs are changed", () => {
+    // Set due date to exactly 1 week later at 10AM
+    const inOneWeek = new Date();
+    inOneWeek.setDate(inOneWeek.getDate() + 7);
+    const day = inOneWeek.getDate();
+    const month = inOneWeek.getMonth() + 1; // months are 0-indexed
+    const year = inOneWeek.getFullYear();
+    const hour = '10';
+    const minute = '00';
+    const period = 'AM';
+
+    // Format the selected date string (e.g., "Sat, Mar 1")
+    const formattedDate = inOneWeek.toLocaleDateString('en-US', {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+    });
+    const expectedTime = '' + hour + ':' + minute + ' ' + period;
+
+    // Set new due date and due time
+    cy.get('ion-datetime').shadow().find('button')
+      .filter(`[data-day="${day}"][data-month="${month}"][data-year="${year}"]`)
+      .should('exist').click({ force: true });
+
+    cy.get('ion-datetime').shadow().find('.time-body').click();  // access due time picker
+    cy.get('.popover-viewport', { timeout: 10000 }).should('be.visible')
+      .within(() => {
+        cy.get('ion-picker-column[aria-label="Select an hour"]').find('ion-picker-column-option')
+          .contains(hour).shadow().find('button').click({ force: true });
+        cy.get('ion-picker-column[aria-label="Select a minute"]').find('ion-picker-column-option')
+          .contains(minute).shadow().find('button').click({ force: true });
+        cy.get('ion-picker-column[aria-label="Select a day period"]').find('ion-picker-column-option')
+          .contains(period).shadow().find('button').click({ force: true });
+      });
+      cy.get('body').click(0, 0);  // exit time pickergi
+
+    // Verify that the selected date and time are 1 week later at 10AM
+    cy.get('ion-datetime').shadow().find('.datetime-selected-date').should('have.text', formattedDate);
+    cy.get('ion-datetime').shadow().find('.time-body').should('have.text', expectedTime);
+  });
+
+  it("should not allow due dates in the past", () => {
+    // Set due date to exactly 1 week ago
+    const oneWeekAgo = new Date();
+    oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
+    const day = oneWeekAgo.getDate();
+    const month = oneWeekAgo.getMonth() + 1; // months are 0-indexed
+    const year = oneWeekAgo.getFullYear();
+
+    // Check that invalid date button is disabled
+    cy.get('ion-datetime').shadow().find('button')
+      .filter(`[data-day="${day}"][data-month="${month}"][data-year="${year}"]`)
+      .should('exist').should('have.attr', 'disabled');
+  });
+
+  it("should correctly update the tags field", () => {
+    const selectedTags = ["Assignment", "Exam"];
+
+    // Open Tags selection, select tags, and click OK
+    cy.get("ion-select[label='Tags']").click();
+    selectedTags.forEach((tag) => {
+      cy.contains(".alert-checkbox-label", tag).parent().click();
+    });
+    cy.get('button').contains('OK').click();
+
+    // Verify that the tags field is updated with the selected tags
+    cy.get("ion-select[label='Tags']").shadow().find("div.select-text").should("contain.text", selectedTags.join(", "));
+  });
+
+  it("should correctly update the task time estimate input field", () => {
+    // Default value should be 3 from pre-created task
+    cy.get("ion-input[label='Time Estimate (hours)']").find('input').should('have.value', 3);
+
+    // Set valid input, check value
+    const taskTime = "5";
+    cy.get("ion-input[label='Time Estimate (hours)']").find('input').clear()
+    cy.get("ion-input[label='Time Estimate (hours)']").find('input').type("{moveToEnd}" + taskTime);
+    cy.get("ion-input[label='Time Estimate (hours)']").find('input').should('have.value', taskTime);
+  });
+
+  it("should not allow negative or non-numeric time estimates", () => {
+    // Negative numbers should trigger reverting field to 0
+    const negativeTime = "5{moveToStart}-";
+    cy.get("ion-input[label='Time Estimate (hours)']").find('input').clear().type(negativeTime);
+    cy.get("ion-input[label='Time Estimate (hours)']").find('input').should('have.value', 0);
+  });
+
+  // ==============================
+  //         Task creation
+  // ==============================
+  it("should display an error when trying to create a task without a name", () => {
+    cy.get("ion-input").eq(0).find('input').clear();
+    cy.get('.create-task-button').click();
+    cy.get('.invalid-task-message').should("contain", "<Name> is required!");
+  });
+
+  it("should successfully submit form when creating a valid task", () => {
+    cy.fixture('newtask.json').then((fixtureData) => {
+      cy.intercept('PATCH', 'http://localhost:5050/api/createTasks/updatetask/123', {
+        statusCode: 200,
+        body: {
+          message: 'Task updated successfully!',
+          taskId: '123', // mock taskId
+          task: fixtureData.newTask, // use the mock task data from the fixture-- not accurate!
+        },
+      }).as('createTask');
+    });
+
+    // Change task name
+    const newTaskName = "This is a NEW task name, I've updated it!";
+    cy.get("ion-input").eq(0).find('input').clear().type(newTaskName);
+    cy.get("ion-input").eq(0).find('input').should('have.value', newTaskName);
+    cy.get('.create-task-button').click();
+
+    // Update task
+    cy.wait("@createTask", { timeout: 10000 });
+    cy.url().should("include", "/viewtask/123");
+  });
+});

--- a/frontend/cypress/fixtures/newtask.json
+++ b/frontend/cypress/fixtures/newtask.json
@@ -14,6 +14,22 @@
     "total_time_estimate": 3,
 
     "completed": false
-    }
+    },
+  "updatedTask": {
+    "user_id": "yq8aiGeS8VmMGzjjDuugSBXy2",
+
+    "name": "This is a NEW task name, I've updated it!",
+    "notes": "",
+    "location": "",
+    "due_datetime": "2025-02-21T07:59:00.000Z",
+
+    "course_id": null,
+    "tags": [],
+
+    "time_spent": 0,
+    "total_time_estimate": 3,
+
+    "completed": false
+  }
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,7 +15,7 @@ import { useLocation, useParams } from "react-router-dom";
 import Login from "./pages/Login";
 import Signup from "./pages/Signup";
 import CreateTaskButton from "./components/CreateTaskButton";
-import CreateTask from "./pages/CreateTask";
+import { CreateTask, EditTask } from "./pages/CreateTask";
 import TaskList from "./pages/TaskList";
 import CreateAccountPreferences from "./pages/CreateAccountPreferences";
 import CreateAccountPrefPage2 from "./pages/CreateAccountPrefPage2";
@@ -73,6 +73,7 @@ const RenderContent: React.FC = () => {
         <Route exact path="/signup" component={Signup} />
         <ProtectedRoute exact path="/tasklist" component={TaskList} />
         <ProtectedRoute exact path="/createtask" component={CreateTask} />
+        <ProtectedRoute exact path="/edittask/:id" component={EditTask} />
         <ProtectedRoute exact path="/create_acct_pref" component={CreateAccountPreferences} />
         <ProtectedRoute exact path="/create_acct_pref_pg2" component={CreateAccountPrefPage2} />
         <ProtectedRoute path="/viewtask/:id" component={ViewTask} />

--- a/frontend/src/components/CreateTaskButton.tsx
+++ b/frontend/src/components/CreateTaskButton.tsx
@@ -9,8 +9,11 @@ const CreateTaskButton: React.FC = () => {
   const location = useLocation();
   const history = useHistory();
 
-  // Hide the button on the login page
-  if (excludedPages.includes(location.pathname)) {
+  // Hide the button on various app pages
+  const isExcluded = excludedPages.includes(location.pathname) ||
+    /^\/(edittask|viewtask)\/.+/.test(location.pathname);
+
+  if (isExcluded) {
     return null;
   }
 

--- a/frontend/src/interfaces/TaskInterface.tsx
+++ b/frontend/src/interfaces/TaskInterface.tsx
@@ -33,3 +33,17 @@ export interface CurrentTask {
 
   total_time_estimate: number;
 }
+
+export interface FullQueriedTask {
+  completed: boolean;
+  course_id: string | null;
+  due_datetime: string;
+  id: string;
+  location: string;
+  name: string;
+  notes: string;
+  tags: Array<Tag>;
+  time_spent: number;
+  total_time_estimate: number;
+  user_id: string;
+};

--- a/frontend/src/interfaces/TaskInterface.tsx
+++ b/frontend/src/interfaces/TaskInterface.tsx
@@ -20,3 +20,16 @@ export interface NewTask {
 
   completed: boolean;
 }
+
+export interface CurrentTask {
+  name: string;
+  notes: string;
+  location: string;
+
+  due_datetime: Date;
+  course_id: String | null;
+
+  tags: Array<Tag>;
+
+  total_time_estimate: number;
+}

--- a/frontend/src/pages/CreateTask.tsx
+++ b/frontend/src/pages/CreateTask.tsx
@@ -78,7 +78,6 @@ export const CreateTask: React.FC = () => {
 
         completed: false,
       };
-      console.log("Full new task:", newTask);
 
       const response = await fetch("http://localhost:5050/api/createTasks/addnewtask", {
         method: 'POST',
@@ -128,7 +127,6 @@ export const EditTask: React.FC <EditTaskProps>= ({ params }) => {
       }
 
       const data = await response.json();
-      console.log("Task Data:", data);
 
       const currentTask: CurrentTask = {
         name: data.task.name,

--- a/frontend/src/pages/CreateTask.tsx
+++ b/frontend/src/pages/CreateTask.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useHistory } from "react-router-dom";
+import { useHistory, useLocation } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
 import {
   InputChangeEventDetail,
@@ -32,7 +32,7 @@ import {
 } from "@ionic/react";
 import { closeOutline } from 'ionicons/icons';
 
-import { NewTask, CurrentTask } from '../interfaces/TaskInterface';
+import { NewTask, CurrentTask, FullQueriedTask } from '../interfaces/TaskInterface';
 import { Course } from '../interfaces/CourseInterface';
 import { Tag } from '../interfaces/TagInterface';
 
@@ -108,55 +108,34 @@ interface EditTaskProps {
   };
 }
 
+interface LocationState {
+  task: FullQueriedTask;
+}
+
 export const EditTask: React.FC <EditTaskProps>= ({ params }) => {
   const history = useHistory();
+  const location = useLocation<{ state: LocationState }>();
+
+  // @ts-ignore
+  const task = location.state?.task; // VSCode typing has incorrect error
   const [ taskData, setTaskData ] = useState<CurrentTask | null>(null);
-  const [ loading, setLoading ] = useState(true);
-  const [ error, setError ] = useState<string | null>(null);
-
-  const getTaskData = async () => {
-    console.log(`Fetching task with ID: ${params.id}`);
-    try {
-      const response = await fetch(`http://localhost:5050/api/viewTask/getTask/${params.id}`, {
-        method: "GET",
-        headers: { "Content-Type": "application/json" },
-      });
-
-      if (!response.ok) {
-        throw new Error("Failed to fetch task");
-      }
-
-      const data = await response.json();
-
-      const currentTask: CurrentTask = {
-        name: data.task.name,
-        notes: data.task.notes,
-        location: data.task.location,
-
-        due_datetime: new Date(data.task.due_datetime),
-        course_id: data.task.course_id,
-
-        tags: data.task.tags,
-
-        total_time_estimate: data.task.total_time_estimate,
-      };
-
-      console.log("Current Task:", currentTask);
-      setTaskData(currentTask);
-    } catch (error) {
-      console.error("Error fetching task:", error);
-      setError("Failed to load task");
-    } finally {
-      setLoading(false);
-    }
-  };
 
   useEffect(() => {
-    getTaskData();
-  }, [params.id]);
-
-  if (loading) return <p>Loading task...</p>;
-  if (error) return <p>{error}</p>;
+    console.log("Loading task data from View Task into Edit Task...")
+    if (task) {
+      const currentTask: CurrentTask = {
+        name: task.name,
+        notes: task.notes,
+        location: task.location,
+        due_datetime: new Date(task.due_datetime),
+        course_id: task.course_id,
+        tags: task.tags,
+        total_time_estimate: task.total_time_estimate,
+      };
+      console.log("Loaded in task data: ", currentTask);
+      setTaskData(currentTask);
+    }
+  }, [task]);
 
   if (!taskData) {
     return <p>Task data not found</p>;

--- a/frontend/src/pages/CreateTask.tsx
+++ b/frontend/src/pages/CreateTask.tsx
@@ -27,7 +27,10 @@ import {
   IonSelectOption,
   IonButtons,
   IonText,
+  IonBackButton,
+  IonIcon,
 } from "@ionic/react";
+import { closeOutline } from 'ionicons/icons';
 
 import { NewTask, CurrentTask } from '../interfaces/TaskInterface';
 import { Course } from '../interfaces/CourseInterface';
@@ -283,12 +286,11 @@ const TaskForm: React.FC<TaskFormProps> = ({ mode, prevTaskData, onSubmit }) => 
     <IonPage>
       <IonHeader>
         <IonToolbar>
-          <IonButton
-            slot="start"
-            size="small"
-            style={{ paddingLeft: '10px', paddingRight: '10px' }}
-            onClick={handleBack}>X
-          </IonButton>
+          <IonButtons slot="start">
+            <IonButton slot="start" onClick={handleBack}>
+              <IonIcon icon={closeOutline} size="large"></IonIcon>
+            </IonButton>
+          </IonButtons>
           <IonTitle>{mode === "create" ? "Create" : "Edit"} Task</IonTitle>
         </IonToolbar>
       </IonHeader>

--- a/frontend/src/pages/ViewTask.css
+++ b/frontend/src/pages/ViewTask.css
@@ -1,3 +1,8 @@
+.nav-button-container {
+  position: relative;
+  width: 100%;
+}
+
 .back-button {
     position: absolute;
     top: 10px;
@@ -14,8 +19,15 @@
     border-radius: 50%;
 }
 
+.edit-button {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  padding: 5px 15px;
+}
+
 .content-wrapper {
-    padding-top: 40px; /* Adjust this value as needed to create space for the back button */
+    padding-top: 55px; /* Adjust this value as needed to create space for the back button */
 }
 
 .task-name h1 {
@@ -28,7 +40,7 @@
     align-items: center;
     justify-content: space-between;
 }
-  
+
 .details p {
     font-size: 1em;
     margin: 10px 0;
@@ -41,7 +53,7 @@
     border-radius: 4px;
     font-size: 1.5em;
 }
-  
+
 .description p {
     font-size: 1em;
     margin: 10px 0;
@@ -58,7 +70,7 @@
 .timer-display h2 {
     font-size: 2em;
     margin-bottom: 15px;
-}   
+}
 
 .disabled-timer {
     color: lightgray;
@@ -76,10 +88,10 @@
 }
 
 .timer-button {
-    width: 80px; 
-    height: 50px; 
-    margin: 10px; 
-    font-size: 16px; 
+    width: 80px;
+    height: 50px;
+    margin: 10px;
+    font-size: 16px;
     line-height: 3;
 }
 
@@ -90,8 +102,8 @@
     margin-top: 10px;
     display: flex;
     align-items: center;
-    justify-content: center; 
-    margin: 20px auto; 
+    justify-content: center;
+    margin: 20px auto;
     margin-bottom: 0px;
 }
 

--- a/frontend/src/pages/ViewTask.css
+++ b/frontend/src/pages/ViewTask.css
@@ -1,10 +1,5 @@
-.nav-button-container {
-  position: relative;
-  width: 100%;
-}
-
 .back-button {
-    position: absolute;
+    /* position: absolute; */
     top: 10px;
     left: 10px;
     width: 30px;
@@ -20,15 +15,18 @@
 }
 
 .edit-button {
-  position: absolute;
+  /* position: absolute; */
   top: 10px;
   right: 10px;
-  padding: 5px 15px;
+  /* padding: 5px 15px; */
+  display: flex;
+  /* border-radius: 10%;
+  border: 1px solid; */
 }
 
-.content-wrapper {
-    padding-top: 55px; /* Adjust this value as needed to create space for the back button */
-}
+/* .content-wrapper {
+    padding-top: 1%; /* Adjust this value as needed to create space for the back button
+} */
 
 .task-name h1 {
     font-size: 1.5em;

--- a/frontend/src/pages/ViewTask.tsx
+++ b/frontend/src/pages/ViewTask.tsx
@@ -20,9 +20,9 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
   const [task, setTask] = useState<{ name: string, notes: string, total_time_estimate: number, priority: number, completed: boolean, due_datetime: string, time_spent: number } | null>(null); // Ensure correct type
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [checkboxLoading, setCheckboxLoading] = useState(false); 
-  const [loadingTimeSpent, setLoadingTimeSpent] = useState(false); 
-  const [anotherTaskRunning, setAnotherTaskRunning] = useState(false); 
+  const [checkboxLoading, setCheckboxLoading] = useState(false);
+  const [loadingTimeSpent, setLoadingTimeSpent] = useState(false);
+  const [anotherTaskRunning, setAnotherTaskRunning] = useState(false);
   const [showModal, setShowModal] = useState(false);
   const [manualHours, setManualHours] = useState<number | null>(null);
   const [manualMinutes, setManualMinutes] = useState<number | null>(null);
@@ -67,7 +67,7 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
         method: "GET",
         headers: { "Content-Type": "application/json" },
       });
-  
+
       if (!response.ok) {
         throw new Error("Failed to fetch task");
       }
@@ -96,7 +96,7 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
 
   // Check if another task's timer is running
   useEffect(() => {
-    const taskInProgress = JSON.parse(localStorage.getItem('isRunning') || "false") || 
+    const taskInProgress = JSON.parse(localStorage.getItem('isRunning') || "false") ||
                           JSON.parse(localStorage.getItem('isPaused') || "false"); // parse it as a bool
     const runningTaskId = localStorage.getItem('runningTaskId');
     if (taskInProgress === true && runningTaskId && runningTaskId !== params.id) {
@@ -118,16 +118,16 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
       clearInterval(timerInterval);
     }
     return () => clearInterval(timerInterval);
-  }, [isRunning, isPaused]); 
+  }, [isRunning, isPaused]);
 
-  // Set timer state 
+  // Set timer state
   useEffect(() => {
     localStorage.setItem('timer', timer.toString());
     localStorage.setItem('isRunning', JSON.stringify(isRunning));
     localStorage.setItem('isPaused', JSON.stringify(isPaused));
 
     if (isRunning && !isPaused) {
-      // We only want to track elapsed time if the timer is running 
+      // We only want to track elapsed time if the timer is running
       localStorage.setItem('startTime', Date.now().toString());
     } else {
       localStorage.removeItem('startTime');
@@ -136,6 +136,10 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
 
   const handleBack = () => {
     history.replace("/tasklist");
+  };
+
+  const handleEdit = () => {
+    history.push(`/edittask/${params.id}`);
   };
 
   // Timer start/resume
@@ -167,13 +171,13 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
     setShowModal(true)
   };
 
-  // Submit clicked 
+  // Submit clicked
   const handleManualTimeSubmit = async () => {
-    // Update the time 
-    const additionalTime = (manualHours ?? 0) + (manualMinutes ?? 0) / 60; 
+    // Update the time
+    const additionalTime = (manualHours ?? 0) + (manualMinutes ?? 0) / 60;
     await updateTimeSpent(additionalTime);
 
-    // Reset any timer 
+    // Reset any timer
     setIsRunning(false);
     setIsPaused(false);
     setTimer(0);
@@ -206,11 +210,11 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
       });
-  
+
       if (!response.ok) {
         throw new Error("Failed to fetch task");
       }
-  
+
       const data = await response.json();
       console.log("Response Data:", data);
     } catch (error) {
@@ -224,11 +228,11 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
       });
-  
+
       if (!response.ok) {
         throw new Error("Failed to fetch task");
       }
-  
+
       const data = await response.json();
       console.log("Response Data:", data);
     } catch (error) {
@@ -246,11 +250,11 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ additionalTime }),
       });
-  
+
       if (!response.ok) {
         throw new Error("Failed to update time spent");
       }
-  
+
       const data = await response.json();
       console.log("Response Data:", data);
 
@@ -286,10 +290,15 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
       </IonToolbar>
       <IonContent className="ion-padding">
         {/* Back button always renders */}
-        <IonButton className="back-button" onClick={handleBack}>
-          &#8592; {/* Unicode for left arrow */}
-        </IonButton>
-  
+        <div className="nav-button-container">
+          <IonButton className="back-button" onClick={handleBack}>
+            &#8592; {/* Unicode for left arrow */}
+          </IonButton>
+          <IonButton className="edit-button" onClick={handleEdit}>
+            Edit
+          </IonButton>
+        </div>
+
         {/* Show loading state */}
         {loading ? (
           <IonText>Loading task...</IonText>
@@ -314,13 +323,13 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
               </IonText>
               {task.priority !== undefined && (
                 <div className="priority-box">P{task.priority}</div>
-              )} 
+              )}
             </div>
             <IonItemDivider />
             <IonText className="description">
               <p><strong>Description:</strong></p>
               <p>
-                {task.notes} 
+                {task.notes}
               </p>
             </IonText>
             <IonItemDivider />
@@ -338,7 +347,7 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
               {/* Timer control buttons */}
               <div className="timer-buttons">
               {anotherTaskRunning ? (
-                  <IonText className="another-task-message">You have a task in progress: <strong>{localStorage.getItem('runningTaskName')}</strong>. 
+                  <IonText className="another-task-message">You have a task in progress: <strong>{localStorage.getItem('runningTaskName')}</strong>.
                   Please stop it before starting this task.</IonText>
                 ) : (
                   <>
@@ -349,7 +358,7 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
                     ) : (
                       <IonButton className="timer-button" onClick={handleStart}>Start Task</IonButton>
                     )}
-    
+
                     {/* Show Stop button only when the timer has started */}
                     {(isRunning || isPaused) && (
                       <IonButton className="timer-button" onClick={handleStop} color="danger">Stop Task</IonButton>
@@ -361,9 +370,9 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
             {/* Manual time entry */}
             <IonItemDivider />
             <div title={anotherTaskRunning ? "Please stop the other task to enter time." : ""}>
-              <IonButton 
-                className="manual-time" 
-                color="medium" 
+              <IonButton
+                className="manual-time"
+                color="medium"
                 onClick={() => setShowModal(true)}
                 disabled={anotherTaskRunning}
               >
@@ -401,31 +410,31 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
             </IonItem>
             <IonItem>
               <IonLabel position="stacked">Hours</IonLabel>
-              <IonInput 
-                type="number" 
+              <IonInput
+                type="number"
                 inputmode="numeric"
-                min="0" 
-                step="1" 
-                value={manualHours} 
+                min="0"
+                step="1"
+                value={manualHours}
                 onIonChange={e => {
                   const value = parseInt(e.detail.value!, 10);
                   setManualHours(isNaN(value) || value < 0 ? 0 : value);
-                }} 
+                }}
               />
             </IonItem>
             <IonItem>
               <IonLabel position="stacked">Minutes</IonLabel>
-              <IonInput 
-                type="number" 
+              <IonInput
+                type="number"
                 inputmode="numeric"
-                min="0" 
-                max="59" 
-                step="1" 
-                value={manualMinutes} 
+                min="0"
+                max="59"
+                step="1"
+                value={manualMinutes}
                 onIonChange={e => {
                   const value = parseInt(e.detail.value!, 10);
                   setManualMinutes(isNaN(value) || value < 0 ? 0 : value);
-                }} 
+                }}
               />
             </IonItem>
             <IonButton expand="block" onClick={handleManualTimeSubmit}>Submit</IonButton>
@@ -434,7 +443,7 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
         </IonModal>
       </IonContent>
     </IonPage>
-  );  
+  );
 };
 
 export default ViewTask;

--- a/frontend/src/pages/ViewTask.tsx
+++ b/frontend/src/pages/ViewTask.tsx
@@ -139,7 +139,10 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
   };
 
   const handleEdit = () => {
-    history.push(`/edittask/${params.id}`);
+    history.push({
+      pathname: `/edittask/${params.id}`,
+      state: { task },
+    });
   };
 
   // Timer start/resume

--- a/frontend/src/pages/ViewTask.tsx
+++ b/frontend/src/pages/ViewTask.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { IonButton, IonContent, IonPage, IonTitle, IonToolbar, IonText, IonItemDivider, IonSpinner, IonModal, IonItem, IonLabel, IonInput } from "@ionic/react";
+import { IonButton, IonButtons, IonContent, IonPage, IonTitle, IonToolbar, IonText, IonItemDivider, IonSpinner, IonModal, IonItem, IonLabel, IonInput, IonHeader } from "@ionic/react";
 import { useHistory } from "react-router-dom";
 import { useLocation } from "react-router-dom";
 import './ViewTask.css'; // Import the CSS file
@@ -285,20 +285,23 @@ const ViewTask: React.FC<ViewTaskProps> = ({params}) => {
 
   return (
     <IonPage key={forceUpdate}>
-      <IonToolbar>
-        <IonTitle>View Task</IonTitle>
-      </IonToolbar>
+      <IonHeader>
+        <IonToolbar>
+            {/* Back button always renders */}
+            <IonButtons slot="start">
+              <IonButton className="back-button" onClick={handleBack}>
+                  &#8592; {/* Unicode for left arrow */}
+              </IonButton>
+            </IonButtons>
+            <IonTitle>View Task</IonTitle>
+            <IonButtons slot="end">
+              <IonButton className="edit-button" onClick={handleEdit}>
+                Edit
+              </IonButton>
+            </IonButtons>
+        </IonToolbar>
+      </IonHeader>
       <IonContent className="ion-padding">
-        {/* Back button always renders */}
-        <div className="nav-button-container">
-          <IonButton className="back-button" onClick={handleBack}>
-            &#8592; {/* Unicode for left arrow */}
-          </IonButton>
-          <IonButton className="edit-button" onClick={handleEdit}>
-            Edit
-          </IonButton>
-        </div>
-
         {/* Show loading state */}
         {loading ? (
           <IonText>Loading task...</IonText>


### PR DESCRIPTION
Users can now edit a selected task from the task's "View Task" page. The "Edit Task" page is just the Create Task page, with the fields imported from the existing task (queried from View Task). Closes issue #155.

**Changes:**
- Moved "back" and "edit" buttons in View Task to the page header to streamline page layout
- Added additional controller/router functions for updating task data
- Refactored CreateTask page to display same TaskForm for both CreateTask and EditTask

**Testing:**
- Added cypress tests for Edit Task page-- similar to Create Task tests, but routing from View Task instead. Checks that fields are populated with data from existing task.