### PR TITLE
added frontend node modules / vite stuff to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 Thumbs.db
 backend/serviceAccountKey.json
 backend/serviceAccountKey.json
+frontend/node_modules/.vite/deps/


### PR DESCRIPTION
Noticed that four node_module files in frontend kept showing up for git and always bugged you to get committed or stashed before switching branches, so I just added frontend/node_modules/.vite/deps/ to the gitignore